### PR TITLE
Add `shoot_button` id

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -52,6 +52,7 @@ kv = """
 
     # Shoot button
     XCameraIconButton:
+        id: shoot_button
         markup: True
         text: root.icon
         icon_color: root.icon_color


### PR DESCRIPTION
It makes it easier to access the button widget from other widget.
For example I want to use XCamera because it has autofocus on Android. But I don't take picture, I only detect QR Codes using `on_texture` event.
https://github.com/AndreMiras/garden.zbarcam
Having access to the button id, or makes it easier for me to remove it using:
```
camera.remove_widget(camera.ids['shoot_button'])
```
This is a quick way around, but it would actually be better to have a boolean to enable/disable that button.