### PR TITLE
Change from renpy to kivy

### DIFF
--- a/android_api.py
+++ b/android_api.py
@@ -4,7 +4,7 @@ from kivy.logger import Logger
 
 Camera = autoclass('android.hardware.Camera')
 AndroidActivityInfo = autoclass('android.content.pm.ActivityInfo')
-AndroidPythonActivity = autoclass('org.renpy.android.PythonActivity')
+AndroidPythonActivity = autoclass('org.kivy.android.PythonActivity')
 
 class ShutterCallback(PythonJavaClass):
     __javainterfaces__ = ('android.hardware.Camera$ShutterCallback', )


### PR DESCRIPTION
P4a now reference classe org.renpy.android.PythonActivity as org.kivy.android.PythonActivity
So if using master branch of p4a in buildozer it crash at execution
